### PR TITLE
Implement BedTypeIndex alias

### DIFF
--- a/src/libslic3r/BuildPlate.hpp
+++ b/src/libslic3r/BuildPlate.hpp
@@ -8,6 +8,8 @@
 namespace Slic3r {
 
 using BedTypeIndex = size_t;
+// Temporary alias for legacy code using BedType
+using BedType = BedTypeIndex;
 
 // Legacy built-in bed type indices kept for compatibility
 constexpr BedTypeIndex btDefault    = 0;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1807,7 +1807,7 @@ enum BambuBedType {
     bbtSuperTackPlate = 5,
 };
 
-static BambuBedType to_bambu_bed_type(BedType type)
+static BambuBedType to_bambu_bed_type(BedTypeIndex type)
 {
     BambuBedType bambu_bed_type = bbtUnknown;
     if (type == btPC)
@@ -3147,9 +3147,9 @@ void GCode::print_machine_envelope(GCodeOutputStream &file, Print &print)
 }
 
 // BBS
-int GCode::get_bed_temperature(const int extruder_id, const bool is_first_layer, const BedType bed_type) const
+int GCode::get_bed_temperature(const int extruder_id, const bool is_first_layer, BedTypeIndex bed_type_idx) const
 {
-    std::string bed_temp_key = is_first_layer ? get_bed_temp_1st_layer_key(bed_type) : get_bed_temp_key(bed_type);
+    std::string bed_temp_key = is_first_layer ? get_bed_temp_1st_layer_key(bed_type_idx) : get_bed_temp_key(bed_type_idx);
     const ConfigOptionInts* bed_temp_opt = m_config.option<ConfigOptionInts>(bed_temp_key);
     return bed_temp_opt->get_at(extruder_id);
 }

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -602,7 +602,7 @@ private:
 
     std::set<unsigned int>                  m_initial_layer_extruders;
     // BBS
-    int get_bed_temperature(const int extruder_id, const bool is_first_layer, const BedType bed_type) const;
+    int get_bed_temperature(const int extruder_id, const bool is_first_layer, BedTypeIndex bed_type_idx) const;
 
     std::string _extrude(const ExtrusionPath &path, std::string description = "", double speed = -1);
     bool _needSAFC(const ExtrusionPath &path);

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -338,7 +338,7 @@ enum CounterboreHoleBridgingOption {
      wtwRib
  };
 
-static std::string bed_type_to_gcode_string(const BedType type)
+static std::string bed_type_to_gcode_string(const BedTypeIndex type)
 {
     std::string type_str;
 
@@ -369,7 +369,7 @@ static std::string bed_type_to_gcode_string(const BedType type)
     return type_str;
 }
 
-static std::string get_bed_temp_key(const BedType type)
+static std::string get_bed_temp_key(const BedTypeIndex type)
 {
     if (type == btSuperTack)
         return "supertack_plate_temp";
@@ -392,7 +392,7 @@ static std::string get_bed_temp_key(const BedType type)
     return "";
 }
 
-static std::string get_bed_temp_1st_layer_key(const BedType type)
+static std::string get_bed_temp_1st_layer_key(const BedTypeIndex type)
 {
     if (type == btSuperTack)
         return "supertack_plate_temp_initial_layer";

--- a/todo.txt
+++ b/todo.txt
@@ -17,8 +17,9 @@
       • struct BuildPlateDef { std::string uuid; std::string display_name; int bambu_code; int def_bed_temp; int def_bed_temp_first; double def_z_offset; }  
       • class BuildPlateManager { static BuildPlateManager& inst(); load/save/CRUD, emits Qt signals }  
 - [PARTIAL] Replace enum BedType everywhere with using BedTypeIndex = size_t
-       • Added BedTypeIndex alias and constants in BuildPlate.hpp.
-       • Removed enum from PrintConfig.hpp but rest of code still uses BedType.
+        • Added BedTypeIndex alias and constants in BuildPlate.hpp.
+        • Added temporary alias using BedType = BedTypeIndex.
+        • Updated GCode APIs and helper functions to take BedTypeIndex.
 - [PARTIAL] Inline helper: static const BuildPlateDef& plate(BedTypeIndex)
        • Added inline accessor in BuildPlateManager. Further integration pending.
 


### PR DESCRIPTION
## Summary
- alias `BedType` to new `BedTypeIndex`
- update helper functions in `PrintConfig.hpp` to take indexes
- migrate GCode API to new index parameter
- note progress in TODO

## Testing
- `ctest -N`

------
https://chatgpt.com/codex/tasks/task_b_68526e6be4c483299db7a477418da004