### PR TITLE
Implement initial bed_type_idx option

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -375,6 +375,9 @@ void AppConfig::set_defaults()
     if (get("curr_bed_type").empty()) {
         set("curr_bed_type", "1");
     }
+    if (get("bed_type_idx").empty()) {
+        set("bed_type_idx", "1");
+    }
 
     if (get("sending_interval").empty()) {
         set("sending_interval", "5");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -809,12 +809,18 @@ void PrintConfigDef::init_fff_params()
     def->max = 300;
     def->set_default_value(new ConfigOptionInts{45});
 
-    def = this->add("curr_bed_type", coEnum);
+    def = this->add("bed_type_idx", coInt);
+    def->label = L("Bed plate index");
+    def->tooltip = L("Index of selected build plate.");
+    def->mode = comSimple;
+    def->min = 0;
+    def->set_default_value(new ConfigOptionInt(btPC));
+
+    def = this->add("curr_bed_type", coEnum); // legacy
     def->label = L("Bed type");
     def->tooltip = L("Bed types supported by the printer.");
     def->mode = comSimple;
     def->enum_keys_map = &s_keys_map_BedType;
-    // Orca: make sure the order of the values is the same as the BedType enum 
     def->enum_values.emplace_back("Cool Plate");
     def->enum_values.emplace_back("Engineering Plate");
     def->enum_values.emplace_back("High Temp Plate");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1238,7 +1238,8 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     // BBS
     ((ConfigOptionString,             bed_custom_texture))
     ((ConfigOptionString,             bed_custom_model))
-    ((ConfigOptionEnum<BedType>,      curr_bed_type))
+    ((ConfigOptionInt,               bed_type_idx))
+    ((ConfigOptionEnum<BedType>,      curr_bed_type)) // legacy
     ((ConfigOptionInts,               cool_plate_temp))
     ((ConfigOptionInts,               textured_cool_plate_temp))
     ((ConfigOptionInts,               supertack_plate_temp))

--- a/todo.txt
+++ b/todo.txt
@@ -28,7 +28,8 @@
 ====================================================
 2. PRINTCONFIG & PRESET PERSISTENCE
 ====================================================
-- [ ] src/libslic3r/PrintConfig.hpp: rename bed_type → bed_type_idx (size_t)
+- [PARTIAL] src/libslic3r/PrintConfig.hpp: rename bed_type → bed_type_idx (size_t)
+      • Added new bed_type_idx ConfigOptionInt alongside legacy curr_bed_type.
 - [ ] Printer preset INI: add [build_plates] section, one stanza per plate
 - [ ] Filament preset INI: replace hard-coded *_plate_temp keys with  
       [bed_temps] uuid = "<uuid>" bed_temp = 60 first_layer = 65


### PR DESCRIPTION
## Summary
- introduce `bed_type_idx` as new ConfigOptionInt
- keep legacy `curr_bed_type` for now
- default `bed_type_idx` in AppConfig
- update TODO with notes

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_68527a939b5c8329b197ed590fdaa244