### PR TITLE
Add BuildPlateManager unit tests

### DIFF
--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -21,9 +21,10 @@ add_executable(${_TEST_NAME}_tests
     test_optimizers.cpp
     test_png_io.cpp
     test_timeutils.cpp
-    test_indexed_triangle_set.cpp
-    ../libnest2d/printer_parts.cpp
-	)
+        test_indexed_triangle_set.cpp
+        test_buildplate_manager.cpp
+        ../libnest2d/printer_parts.cpp
+        )
 
 if (TARGET OpenVDB::openvdb)
     target_sources(${_TEST_NAME}_tests PRIVATE test_hollowing.cpp)

--- a/tests/libslic3r/test_buildplate_manager.cpp
+++ b/tests/libslic3r/test_buildplate_manager.cpp
@@ -1,0 +1,38 @@
+#include <catch2/catch.hpp>
+#include "libslic3r/BuildPlate.hpp"
+#include <filesystem>
+using namespace Slic3r;
+
+TEST_CASE("BuildPlateManager CRUD and serialization", "[BuildPlateManager]") {
+    auto &mgr = BuildPlateManager::inst();
+    mgr.load_defaults();
+    size_t start_count = mgr.plates().size();
+    BuildPlateDef def{BuildPlateManager::gen_uuid(), "Test Plate", 9, 60, 65, 0.1};
+    REQUIRE(mgr.add_plate(def));
+    auto idx_opt = mgr.index_from_uuid(def.uuid);
+    REQUIRE(idx_opt);
+    size_t idx = *idx_opt;
+    REQUIRE(mgr.plates().size() == start_count + 1);
+    BuildPlateDef def2 = def;
+    def2.display_name = "Renamed";
+    REQUIRE(mgr.update_plate(idx, def2));
+    REQUIRE(mgr.plate(idx).display_name == "Renamed");
+    std::filesystem::path p = std::filesystem::temp_directory_path() / "plates_test.json";
+    REQUIRE(mgr.save(p.string()));
+    mgr.load_defaults();
+    REQUIRE(mgr.plates().size() == start_count);
+    REQUIRE(mgr.load(p.string()));
+    REQUIRE(mgr.plates().size() == start_count + 1);
+    REQUIRE(mgr.plate(idx).display_name == "Renamed");
+    REQUIRE(mgr.remove_plate(idx));
+    REQUIRE(mgr.plates().size() == start_count);
+    std::filesystem::remove(p);
+}
+
+TEST_CASE("BuildPlateManager UUID generation", "[BuildPlateManager]") {
+    std::string u1 = BuildPlateManager::gen_uuid();
+    std::string u2 = BuildPlateManager::gen_uuid();
+    REQUIRE(u1 != u2);
+    REQUIRE(u1.size() == 32);
+    REQUIRE(u2.size() == 32);
+}

--- a/todo.txt
+++ b/todo.txt
@@ -50,8 +50,10 @@
 ====================================================
 4. BACKEND VALIDATION & TESTS
 ====================================================
-- [ ] tests/unit/TestBuildPlateManager.cpp  
-      • CRUD ops, UUID stability, reorder, serialization round-trip
+- [PARTIAL] tests/unit/TestBuildPlateManager.cpp
+      • CRUD ops implemented for BuildPlateManager, covering add/update/remove and
+        serialization round-trip. Reorder and comprehensive UUID stability tests
+        still pending.
 - [ ] tests/unit/TestMigration.cpp — load v2.3 preset, expect auto-conversion
 - [ ] tests/integration/TestGcodePlate.cpp — slice cube, assert M190 values
 - [ ] Catch2 added to CMake if not present


### PR DESCRIPTION
## Summary
- add a new Catch2 unit test covering BuildPlateManager CRUD and UUID handling
- hook the new test into libslic3r test suite
- update todo with progress on tests

## Testing
- `cmake .. -DSLIC3R_BUILD_TESTS=ON` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_b_6852967acb6483299e0290c1954cdd98