### PR TITLE
Update bed-plate docs

### DIFF
--- a/doc/bed-types.md
+++ b/doc/bed-types.md
@@ -7,14 +7,14 @@ You can set the bed temperature for each bed type in the filament settings as de
 
 ![bed-types](https://github.com/SoftFever/OrcaSlicer/blob/main/doc/images/bed-types.gif?raw=true)
 
-Orca also support `curr_bed_type` variable in custom G-code.
-For example, the following sample G-codes can detect the selected bed type and adjust the G-code offset accordingly for Klipper:
+Orca also supported a `curr_bed_type` variable in custom G-code.  With the new
+build plate manager the preferred approach is to use `plate_z_offset` which
+directly exposes the z offset configured for a plate.  The following sample
+G-code automatically applies the configured offset if it is not zero:
 
 ```c++
-{if curr_bed_type=="Textured PEI Plate"}
-  SET_GCODE_OFFSET Z=-0.05
-{else}
-  SET_GCODE_OFFSET Z=0.0
+{if plate_z_offset != 0}
+  SET_GCODE_OFFSET Z={plate_z_offset}
 {endif}
 ```
 

--- a/todo.txt
+++ b/todo.txt
@@ -80,7 +80,7 @@
 7. Z-OFFSET PER PLATE (OPTIONAL BUT REQUESTED BY COMMUNITY)
 ====================================================
 - [DONE] Add double z_offset field to BuildPlateDef
-- [WIP] Printer Start-G-code sample: {if plate_z_offset != 0}SET_GCODE_OFFSET Z={plate_z_offset}{endif}
+ - [DONE] Printer Start-G-code sample: {if plate_z_offset != 0}SET_GCODE_OFFSET Z={plate_z_offset}{endif}
 - [ ] UI column in Printer Settings ➜ Build Plate manager table
 
 ====================================================


### PR DESCRIPTION
## Summary
- update docs for plate_z_offset example
- mark start gcode doc todo as done

## Testing
- `perl Build.PL` (installs dependencies)
- `cmake .. -DCMAKE_BUILD_TYPE=Release` *(fails: OpenVDB not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852b2f6419c83298df9a975bd804329